### PR TITLE
Statistics object

### DIFF
--- a/src/api/typeApi.ts
+++ b/src/api/typeApi.ts
@@ -111,8 +111,8 @@ export interface StatisticRequestBody {
 export interface OptionStatistic {
     sprint: inGameStats
     audio: inGameStats
-    learnedWordsByDays: object
-    newWordsByDays: object
+    learnedWordsByDays: Map<string, number>
+    newWordsByDays: Map<string, number>
 }
 
 export interface UserSettingsResponse {


### PR DESCRIPTION
Привет!
![image](https://user-images.githubusercontent.com/65382605/187609724-9c006ebd-bc2e-4031-8e77-bf6cf833f049.png)
![image](https://user-images.githubusercontent.com/65382605/187604137-4e55a037-dfd7-45ad-8987-8b5d5e5d2fc1.png)
Есть статистика по каждой игре. Я думал, может сделать игры опциональными, но мне кажется, что предыдущий объект статистики стирается совсем, а не обновляется. Так что все равно в каждой игре придется проверять, если статистика из другой, чтобы не стереть её.
Дату сделал строкой, потому что просто new Date(), содержит лишнее.
![image](https://user-images.githubusercontent.com/65382605/187604629-d638be65-9e65-4f8c-8820-7624179f1fd3.png)
![image](https://user-images.githubusercontent.com/65382605/187605290-0ccc0ff9-97d6-4f2b-9b89-4e746a5c25ff.png)
Формат даты предполагаю такой. Между значениями пробелы. Месяцы тут начинаются с нуля, думаю ничего с этим делать не будем
По аналогии с изученными днями за день, добавил новые слова за день. Нужны будут для графиков. Как ключ будем использовать дату, в указанном выше формате.
learnedWords в таком случае выглядит бесполезной частью, но боюсь, что, если его убрать, то сломается бэк.