### PR TITLE
fix: fix paths to favicon on statistics and textbook pages so that it would be display on them

### DIFF
--- a/src/pages/statistics/statistics.html
+++ b/src/pages/statistics/statistics.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital@0;1&family=Kanit&display=swap" rel="stylesheet">
   <title>RS-Lang: Statistics</title>
-  <link rel="icon" type="image/x-icon" href="../../pictures/favicon.png">
+  <link rel="icon" type="image/x-icon" href="../pictures/favicon.png">
 </head>
 <body>
   <main>

--- a/src/pages/textbook/textbook.html
+++ b/src/pages/textbook/textbook.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital@0;1&family=Kanit&family=Raleway&display=swap" rel="stylesheet">
   <title>RS-Lang: Textbook</title>
-  <link rel="icon" type="image/x-icon" href="../../pictures/favicon.png">
+  <link rel="icon" type="image/x-icon" href="../pictures/favicon.png">
 </head>
 <body>
   <main>


### PR DESCRIPTION
Исправил пути к фавикону на страницах статистики и текстбука так что бы он отбражался на них